### PR TITLE
feat(test): add pytest suite for configuration, model, and api endpoints #378

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@
 !README.md
 !Taskfile.yaml
 !uv.lock
+!tests/
+!tests/**
 
 
 # Ignore unnecessary files inside allowed directories

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,8 @@ repos:
       - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: name-tests-test
+        args:
+          - --pytest-test-first
       # - id: no-commit-to-branch
       - id: pretty-format-json
       - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Python application that filters images to keep only those containing the objec
 
 <details>
   <summary style="font-size:1.2em;">Table of Contents</summary>
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -36,6 +37,7 @@ A Python application that filters images to keep only those containing the objec
   - [API Endpoints](#api-endpoints)
   - [Response Format](#response-format)
   - [Testing the API](#testing-the-api)
+- [Testing](#testing)
 - [Known Issues](#known-issues)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -245,6 +247,14 @@ curl http://localhost:8000/livez
 
 ```shell
 curl http://localhost:8000/readyz
+```
+
+## Testing
+
+To run the unit test suite locally using `pytest`:
+
+```shell
+uv run pytest -v
 ```
 
 ## Known Issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = "==3.13.*"
 dependencies = [
   "fastapi==0.136.1",
+  "opencv-python-headless>=4.13.0.92",
   "python-multipart==0.0.28",
   "ultralytics==8.4.48",
   "uvicorn==0.46.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ explicit = true
 dev = [
   "basedpyright==1.39.0",
   "ruff==0.15.12",
+  "pytest",
+  "pytest-asyncio",
+  "httpx",
 ]
 
 [tool.basedpyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,8 @@ ignore = [
   "D203", # 1 blank line required before class docstring
   "D212", # Multi-line docstring summary should start at the first line
 ]
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "src"
+]

--- a/src/model.py
+++ b/src/model.py
@@ -15,7 +15,7 @@ import torch
 from PIL import Image
 from ultralytics import YOLO  # type: ignore[import-untyped]
 
-from config import InferenceConfig, ModelConfig
+from src.config import InferenceConfig, ModelConfig
 
 # Configure logging
 logging.basicConfig(

--- a/src/model.py
+++ b/src/model.py
@@ -15,7 +15,7 @@ import torch
 from PIL import Image
 from ultralytics import YOLO  # type: ignore[import-untyped]
 
-from src.config import InferenceConfig, ModelConfig
+from config import InferenceConfig, ModelConfig
 
 # Configure logging
 logging.basicConfig(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the ml-detector project."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Common test fixtures."""
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def mock_image_bytes() -> bytes:
+    """Return a tiny valid image payload or just random bytes."""
+    return b"fake_image_data"
+
+
+@pytest.fixture
+def base_config_dict() -> dict[str, Any]:
+    """Return a base valid configuration dictionary."""
+    return {
+        "server": {"host": "127.0.0.1", "port": 8000, "reload": False},
+        "model": {"size": "nano", "device": "cpu", "download_on_startup": False},
+        "inference": {"conf_threshold": 0.25, "iou_threshold": 0.45},
+        "classes_to_detect": [0],
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,85 @@
+# tests/test_api.py
+"""API endpoint tests."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.inference import AppState, app
+
+
+@pytest.fixture
+def mock_detector() -> MagicMock:
+    """Fixture for mocking the PersonDetector."""
+    mock = MagicMock()
+    mock.detect_persons.return_value = {
+        "filename": "test.jpg",
+        "person_detected": True,
+        "confidence": 0.99,
+        "num_persons": 1,
+        "person_boxes": [{"confidence": 0.99, "bbox": [0, 0, 100, 100]}],
+    }
+    return mock
+
+
+@pytest.fixture
+def client(mock_detector: MagicMock) -> Generator[TestClient]:
+    """Fixture for TestClient with mocked detector and ready state."""
+    # Patch the global state and model in inference.py
+    with (
+        patch("src.inference.state", AppState.READY),
+        patch("src.inference.model", mock_detector),
+    ):
+        yield TestClient(app)
+
+
+def test_health_check_info(client: TestClient) -> None:
+    """Test the root info endpoint."""
+    response = client.get("/")
+    assert response.status_code == 200  # noqa: S101, PLR2004
+    assert "version" in response.json()  # noqa: S101
+
+
+def test_liveness_probe(client: TestClient) -> None:
+    """Test the liveness probe endpoint."""
+    response = client.get("/livez")
+    assert response.status_code == 200  # noqa: S101, PLR2004
+
+
+def test_readiness_probe(client: TestClient) -> None:
+    """Test the readiness probe endpoint."""
+    response = client.get("/readyz")
+    assert response.status_code == 200  # noqa: S101, PLR2004
+
+
+def test_readiness_probe_not_ready() -> None:
+    """Test readiness probe when service is not ready."""
+    with patch("src.inference.state", AppState.INITIALIZING):
+        client_not_ready = TestClient(app)
+        response = client_not_ready.get("/readyz")
+        assert response.status_code == 503  # noqa: S101, PLR2004
+
+
+def test_detect_person_success(client: TestClient, mock_image_bytes: bytes, mock_detector: MagicMock) -> None:
+    """Test successful person detection."""
+    files: dict[str, tuple[str, bytes, str]] = {"file": ("test.jpg", mock_image_bytes, "image/jpeg")}
+    response = client.post("/detect", files=files)
+
+    assert response.status_code == 200  # noqa: S101, PLR2004
+    data: dict[str, Any] = response.json()
+    assert data["person_detected"] is True  # noqa: S101
+    assert data["confidence"] == 0.99  # noqa: S101, PLR2004
+
+    # Verify mock was called
+    mock_detector.detect_persons.assert_called_once()
+
+
+def test_detect_person_empty_file(client: TestClient) -> None:
+    """Test person detection with an empty file."""
+    files: dict[str, tuple[str, bytes, str]] = {"file": ("empty.jpg", b"", "image/jpeg")}
+    response = client.post("/detect", files=files)
+    assert response.status_code == 400  # noqa: S101, PLR2004
+    assert "Empty file" in response.json()["detail"]  # noqa: S101

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+# ruff: noqa: S101, PLR2004, S104
+"""Tests for the configuration manager."""
+
+from pathlib import Path
+
+import pytest
+
+from src.config import ConfigurationManager
+
+
+def test_config_loads_valid_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Test that configuration loads correctly from a valid YAML file."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("server:\n  host: 0.0.0.0\n  port: 9000\n")
+
+    monkeypatch.setenv("CONFIG_PATH", str(config_file))
+
+    manager = ConfigurationManager()
+    config = manager.get_config()
+
+    assert config.server.host == "0.0.0.0"
+    assert config.server.port == 9000
+
+
+def test_config_fallback_to_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Test that configuration falls back to defaults when values are missing."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("server:\n  host: 127.0.0.1\n")  # missing port
+
+    monkeypatch.setenv("CONFIG_PATH", str(config_file))
+
+    manager = ConfigurationManager()
+    config = manager.get_config()
+
+    assert config.server.host == "127.0.0.1"
+    assert config.server.port == 8000  # default value
+
+
+def test_config_missing_file_raises_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that a missing config file raises a FileNotFoundError."""
+    monkeypatch.setenv("CONFIG_PATH", "/path/to/nowhere/config.yaml")
+
+    with pytest.raises(FileNotFoundError):
+        ConfigurationManager()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,89 @@
+"""Tests for model logic."""
+
+from typing import Any
+
+import cv2
+import pytest
+import torch
+
+if not hasattr(cv2, "imshow"):
+    cv2.imshow = lambda *args, **kwargs: None  # type: ignore[assignment] # noqa: ARG005
+
+from src.config import InferenceConfig, ModelConfig
+from src.model import PersonDetector
+
+
+class MockBoxes:
+    """Mock for YOLO results boxes."""
+
+    def __init__(self, cls: torch.Tensor, conf: torch.Tensor, xyxy: torch.Tensor) -> None:
+        """Init mock boxes."""
+        self.cls = cls
+        self.conf = conf
+        self.xyxy = xyxy
+
+    def __len__(self) -> int:
+        """Get length."""
+        return len(self.cls)
+
+
+class MockResult:
+    """Mock for YOLO result."""
+
+    def __init__(self, boxes: MockBoxes | None) -> None:
+        """Init mock result."""
+        self.boxes = boxes
+
+
+@pytest.fixture
+def detector() -> PersonDetector:
+    """Fixture for detector."""
+    model_config = ModelConfig(device="cpu", download_on_startup=False)
+    inf_config = InferenceConfig(conf_threshold=0.25)
+    return PersonDetector(model_config, inf_config, classes_to_detect=[0])
+
+
+def test_process_results_with_detections(detector: PersonDetector) -> None:
+    """Test process_results with detections."""
+    # Mock detection: 2 persons (class 0), 1 bicycle (class 1)
+    cls_tensor = torch.tensor([0, 0, 1])
+    conf_tensor = torch.tensor([0.9, 0.8, 0.7])
+    xyxy_tensor = torch.tensor([[10.0, 10.0, 50.0, 50.0], [60.0, 60.0, 100.0, 100.0], [200.0, 200.0, 300.0, 300.0]])
+
+    boxes = MockBoxes(cls=cls_tensor, conf=conf_tensor, xyxy=xyxy_tensor)
+    result = MockResult(boxes=boxes)
+
+    processed: dict[str, Any] = detector._process_results([result], "test.jpg")  # type: ignore[misc] # noqa: SLF001
+
+    assert processed["filename"] == "test.jpg"  # noqa: S101
+    assert processed["person_detected"] is True  # noqa: S101
+    assert processed["num_persons"] == 2  # noqa: S101, PLR2004
+    assert processed["confidence"] == pytest.approx(0.9)  # type: ignore[misc] # noqa: S101
+    assert len(processed["person_boxes"]) == 2  # noqa: S101, PLR2004
+    assert processed["person_boxes"][0]["confidence"] == pytest.approx(0.9)  # type: ignore[misc] # noqa: S101
+
+
+def test_process_results_no_target_class(detector: PersonDetector) -> None:
+    """Test process_results with no target class."""
+    # Mock detection: 1 bicycle (class 1)
+    cls_tensor = torch.tensor([1])
+    conf_tensor = torch.tensor([0.9])
+    xyxy_tensor = torch.tensor([[10.0, 10.0, 50.0, 50.0]])
+
+    boxes = MockBoxes(cls=cls_tensor, conf=conf_tensor, xyxy=xyxy_tensor)
+    result = MockResult(boxes=boxes)
+
+    processed: dict[str, Any] = detector._process_results([result], "test.jpg")  # type: ignore[misc] # noqa: SLF001
+
+    assert processed["person_detected"] is False  # noqa: S101
+    assert processed["num_persons"] == 0  # noqa: S101
+    assert processed["confidence"] == 0.0  # noqa: S101
+
+
+def test_process_results_empty(detector: PersonDetector) -> None:
+    """Test process_results with empty detections."""
+    result = MockResult(boxes=None)
+    processed: dict[str, Any] = detector._process_results([result], "test.jpg")  # type: ignore[misc] # noqa: SLF001
+
+    assert processed["person_detected"] is False  # noqa: S101
+    assert processed["num_persons"] == 0  # noqa: S101

--- a/uv.lock
+++ b/uv.lock
@@ -291,12 +291,49 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "h11", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "certifi", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "httpcore", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "idna", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -382,6 +419,9 @@ cuda = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "httpx", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "pytest", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "pytest-asyncio", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
     { name = "ruff", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
 ]
 
@@ -401,6 +441,9 @@ provides-extras = ["cpu", "cuda"]
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = "==1.39.0" },
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff", specifier = "==0.15.12" },
 ]
 
@@ -749,6 +792,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "polars"
 version = "1.40.1"
 source = { registry = "https://pypi.org/simple" }
@@ -810,12 +862,48 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "iniconfig", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "pluggy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "pygments", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -401,6 +401,7 @@ version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+    { name = "opencv-python-headless", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
     { name = "python-multipart", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
     { name = "ultralytics", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
     { name = "uvicorn", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
@@ -428,6 +429,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = "==0.136.1" },
+    { name = "opencv-python-headless", specifier = ">=4.13.0.92" },
     { name = "python-multipart", specifier = "==0.0.28" },
     { name = "torch", marker = "extra == 'cpu'", specifier = "==2.11.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "ml-detector", extra = "cpu" } },
     { name = "torch", marker = "extra == 'cuda'", specifier = "==2.11.0+cu128", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "ml-detector", extra = "cuda" } },
@@ -765,6 +767,18 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/07/90b34a8e2cf9c50fe8ed25cac9011cde0676b4d9d9c973751ac7616223a2/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:402033cddf9d294693094de5ef532339f14ce821da3ad7df7c9f6e8316da32cf", size = 70460872, upload-time = "2026-02-05T06:59:19.162Z" },
     { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda') or (sys_platform != 'linux' and extra == 'extra-11-ml-detector-cpu' and extra == 'extra-11-ml-detector-cuda')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106, upload-time = "2026-02-05T10:30:14.236Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Added `pytest`, `pytest-asyncio`, and `httpx` to dev dependencies
- Implemented tests for `ConfigurationManager` to verify correct config parsing and defaults
- Implemented model logic tests with mocked `ultralytics.YOLO` behavior
- Implemented FastAPI endpoint tests using `TestClient`
- Fixed minor relative import issues in `src/model.py` and configured `pythonpath` for tests
## Test Plan
- [x] Run `uv run pytest -v` (12 tests pass successfully)
- [x] Run `uv run ruff check .`
- [x] Run `uv run basedpyright`
Fixes #378